### PR TITLE
feat: Implement Bitcoin UTXO Visualizer macOS Application

### DIFF
--- a/BitcoinUTXOVisualizer/BitcoinUTXOVisualizerApp.swift
+++ b/BitcoinUTXOVisualizer/BitcoinUTXOVisualizerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct BitcoinUTXOVisualizerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/BitcoinUTXOVisualizer/Models/CSVFile.swift
+++ b/BitcoinUTXOVisualizer/Models/CSVFile.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct CSVFile: FileDocument {
+    static var readableContentTypes: [UTType] = [.commaSeparatedText]
+    static var writableContentTypes: [UTType] = [.commaSeparatedText, .plainText] // Allow .plainText as fallback
+
+    var text: String
+
+    init(initialText: String = "") {
+        self.text = initialText
+    }
+
+    // This initializer is required for opening documents, not strictly for saving.
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents,
+              let string = String(data: data, encoding: .utf8)
+        else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        text = string
+    }
+
+    // This function is called when saving the document.
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        guard let data = text.data(using: .utf8) else {
+            throw CocoaError(.fileWriteUnknown) // Or a more specific error
+        }
+        return FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/BitcoinUTXOVisualizer/Models/JSONFile.swift
+++ b/BitcoinUTXOVisualizer/Models/JSONFile.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct JSONFile: FileDocument {
+    static var readableContentTypes: [UTType] = [.json]
+    static var writableContentTypes: [UTType] = [.json]
+
+    var text: String
+
+    init(initialText: String = "") {
+        self.text = initialText
+    }
+
+    // This initializer is required for opening documents.
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents,
+              let string = String(data: data, encoding: .utf8)
+        else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        text = string
+    }
+
+    // This function is called when saving the document.
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        guard let data = text.data(using: .utf8) else {
+            throw CocoaError(.fileWriteUnknown) // Or a more specific error
+        }
+        return FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/BitcoinUTXOVisualizer/Models/UTXO.swift
+++ b/BitcoinUTXOVisualizer/Models/UTXO.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+enum ConfirmationStatus: Codable, Hashable {
+    case confirmed
+    case unconfirmed
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ConfirmationStatusCodingKeys.self)
+        if let isConfirmed = try? container.decode(Bool.self, forKey: .confirmed) {
+            self = isConfirmed ? .confirmed : .unconfirmed
+        } else {
+            self = .unconfirmed
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: ConfirmationStatusCodingKeys.self)
+        try container.encode(self == .confirmed, forKey: .confirmed)
+    }
+
+    private enum ConfirmationStatusCodingKeys: String, CodingKey {
+        case confirmed
+    }
+}
+
+struct UTXO: Codable, Identifiable, Hashable {
+    let txid: String
+    let vout: Int
+    let value: Int64 
+
+    let confirmationStatusDetails: ConfirmationStatusDetails 
+
+    let spent: Bool? 
+    let txid_spent: String? 
+    let vin_spent: Int? 
+    let status_spent: ConfirmationStatusDetails? 
+
+    // New field for analytics
+    var originAddress: String? = nil // Optional, populated by BlockchainService
+
+    var id: String { "\(txid):\(vout)" }
+    var amountInBTC: Double { Double(value) / 100_000_000.0 }
+    var status: ConfirmationStatus { confirmationStatusDetails.confirmed ? .confirmed : .unconfirmed }
+    var age: String {
+        if let height = confirmationStatusDetails.block_height, status == .confirmed {
+            return "Block: \(height)"
+        } else {
+            return "Unconfirmed"
+        }
+    }
+    var block_height: Int? { confirmationStatusDetails.block_height }
+    var block_hash: String? { confirmationStatusDetails.block_hash }
+    var block_time: Int? { confirmationStatusDetails.block_time }
+
+    struct ConfirmationStatusDetails: Codable, Hashable {
+        let confirmed: Bool
+        let block_height: Int?
+        let block_hash: String?
+        let block_time: Int?
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case txid
+        case vout
+        case status // Mapped to confirmationStatusDetails
+        case value
+        case spent
+        case txid_spent
+        case vin_spent
+        case status_spent
+        case originAddress // New key for encoding/decoding
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        txid = try container.decode(String.self, forKey: .txid)
+        vout = try container.decode(Int.self, forKey: .vout)
+        value = try container.decode(Int64.self, forKey: .value)
+        confirmationStatusDetails = try container.decode(ConfirmationStatusDetails.self, forKey: .status)
+        spent = try container.decodeIfPresent(Bool.self, forKey: .spent)
+        txid_spent = try container.decodeIfPresent(String.self, forKey: .txid_spent)
+        vin_spent = try container.decodeIfPresent(Int.self, forKey: .vin_spent)
+        status_spent = try container.decodeIfPresent(ConfirmationStatusDetails.self, forKey: .status_spent)
+        originAddress = try container.decodeIfPresent(String.self, forKey: .originAddress) // Decode new field
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(txid, forKey: .txid)
+        try container.encode(vout, forKey: .vout)
+        try container.encode(value, forKey: .value)
+        try container.encode(confirmationStatusDetails, forKey: .status)
+        try container.encodeIfPresent(spent, forKey: .spent)
+        try container.encodeIfPresent(txid_spent, forKey: .txid_spent)
+        try container.encodeIfPresent(vin_spent, forKey: .vin_spent)
+        try container.encodeIfPresent(status_spent, forKey: .status_spent)
+        try container.encodeIfPresent(originAddress, forKey: .originAddress) // Encode new field
+    }
+
+    // Manually provide a copy method to modify originAddress post-initialization if needed
+    // Or, make originAddress a var and set it after decoding if it's not in the JSON source.
+    // For BlockchainService, it will create UTXO objects and then set this field.
+    // For JSON loading, it's better if it's part of the Codable process.
+}

--- a/BitcoinUTXOVisualizer/Services/BlockchainService.swift
+++ b/BitcoinUTXOVisualizer/Services/BlockchainService.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Combine 
+
+enum BlockchainServiceError: Error, LocalizedError {
+    case invalidURL
+    case networkError(Error)
+    case decodingError(Error)
+    case apiError(String) 
+    case noUTXOsFound
+    case xpubNotSupported 
+    case addressDerivationFailed 
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid API URL."
+        case .networkError(let err): return "Network error: \(err.localizedDescription)"
+        case .decodingError(let err): return "Decoding error: \(err.localizedDescription)"
+        case .apiError(let msg): return "API error: \(msg)"
+        case .noUTXOsFound: return "No UTXOs found."
+        case .xpubNotSupported: return "XPUB fetching is not fully supported with this public API."
+        case .addressDerivationFailed: return "Failed to derive addresses from XPUB (simulated)."
+        }
+    }
+}
+
+class BlockchainService {
+    private let baseURL = "https://mempool.space/api/" 
+    private let inputValidator = InputValidator()
+
+    func fetchUTXOs(forInput input: String, completion: @escaping (Result<[UTXO], Error>) -> Void) {
+        let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        /* Privacy Note: ... */
+
+        if inputValidator.isSingleAddress(trimmedInput) {
+            fetchUTXOsForSingleAddress(address: trimmedInput, completion: completion)
+        } else if inputValidator.isCommaSeparatedAddresses(trimmedInput) {
+            fetchUTXOsForMultipleAddresses(addressesString: trimmedInput, completion: completion)
+        } else if inputValidator.isXpub(trimmedInput) {
+            fetchUTXOsForXpub(xpub: trimmedInput, completion: completion)
+        } else {
+            completion(.failure(BlockchainServiceError.apiError("Invalid input format.")))
+        }
+    }
+
+    private func fetchUTXOsForSingleAddress(address: String, completion: @escaping (Result<[UTXO], Error>) -> Void) {
+        guard let url = URL(string: "\(baseURL)address/\(address)/utxo") else {
+            completion(.failure(BlockchainServiceError.invalidURL)); return
+        }
+        performRequest(url: url) { result in
+            switch result {
+            case .success(var utxos):
+                // Populate originAddress for each UTXO
+                for i in 0..<utxos.count {
+                    utxos[i].originAddress = address
+                }
+                completion(.success(utxos))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func fetchUTXOsForMultipleAddresses(addressesString: String, completion: @escaping (Result<[UTXO], Error>) -> Void) {
+        let addresses = addressesString.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        var combinedUTXOs: [UTXO] = []
+        var errors: [Error] = []
+        let dispatchGroup = DispatchGroup()
+
+        for address in addresses {
+            guard inputValidator.isSingleAddress(address) else {
+                errors.append(BlockchainServiceError.apiError("Invalid address in list: \(address)")); continue
+            }
+            dispatchGroup.enter()
+            fetchUTXOsForSingleAddress(address: address) { result in // This will now populate originAddress
+                defer { dispatchGroup.leave() }
+                switch result {
+                case .success(let utxos):
+                    combinedUTXOs.append(contentsOf: utxos)
+                case .failure(let error):
+                    errors.append(error)
+                }
+            }
+        }
+        dispatchGroup.notify(queue: .main) {
+            if !errors.isEmpty && combinedUTXOs.isEmpty {
+                completion(.failure(errors.first ?? BlockchainServiceError.apiError("Multiple address fetch failed.")))
+            } else if !errors.isEmpty {
+                print("Warning: Some addresses failed: \(errors.map { $0.localizedDescription })")
+                completion(.success(combinedUTXOs)) // Partial success
+            } else if combinedUTXOs.isEmpty {
+                completion(.failure(BlockchainServiceError.noUTXOsFound))
+            } else {
+                completion(.success(combinedUTXOs))
+            }
+        }
+    }
+
+    private func fetchUTXOsForXpub(xpub: String, completion: @escaping (Result<[UTXO], Error>) -> Void) {
+        print("Fetching UTXOs for xpub: \(xpub). Note: Using simulated address derivation.")
+        // These dummy addresses are unlikely to have real UTXOs.
+        // For testing analytics, ensure some of these simulated addresses are repeated if you want
+        // to test "multiple UTXOs per address" with xpub input.
+        // Or, use an xpub whose first few derived addresses are known and hardcode those.
+        let derivedAddress1 = "bc1qxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" // Replace with actual derived if testing
+        let derivedAddress2 = "3Jyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" // Replace with actual derived if testing
+        let derivedAddress3 = "bc1qxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" // Same as derivedAddress1 for testing multi-UTXO analytics
+
+        // Simulate deriving a few addresses. In a real scenario, use an HD Wallet library.
+        // For this test, we'll use hardcoded, potentially non-existent addresses.
+        // To test "multiple UTXOs per address" from xpub, we need some UTXOs to share an originAddress.
+        // The current dummy addresses are unique. Let's use a simplified set for now.
+        // If these dummy addresses had UTXOs, the `originAddress` would be set by `fetchUTXOsForSingleAddress`.
+        
+        // For this simulation, we'll use two distinct dummy addresses.
+        // If you want to test the "multiple UTXOs from same derived address" analytic,
+        // you'd need an xpub and two *actual* derived addresses from it that *both* have UTXOs.
+        // Or, modify the simulation to fetch for the *same* dummy address multiple times (which is unrealistic).
+        // The current setup will correctly assign the derived address as `originAddress`.
+        let simulatedAddressesToQuery = [
+            "bc1q0dy0y0dy0y0dy0y0dy0y0dy0y0dy0y0dy0y0dy0y0dysgr9hv", // Dummy 1
+            "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",                     // Dummy 2
+            // To test "multiple UTXOs per originAddress" with xpub, you'd need a real xpub
+            // and know some of its derived addresses that have multiple UTXOs, or
+            // the test sample_utxos.json should include UTXOs with originAddress set.
+            // For now, the logic in fetchUTXOsForMultipleAddresses will handle setting originAddress.
+        ]
+        
+        var combinedUTXOs: [UTXO] = []
+        var errors: [Error] = []
+        let dispatchGroup = DispatchGroup()
+
+        for address in simulatedAddressesToQuery {
+            dispatchGroup.enter()
+            // fetchUTXOsForSingleAddress will set the `originAddress` to `address`
+            fetchUTXOsForSingleAddress(address: address) { result in
+                defer { dispatchGroup.leave() }
+                switch result {
+                case .success(let utxos):
+                    combinedUTXOs.append(contentsOf: utxos)
+                case .failure(let error):
+                    if !(error is BlockchainServiceError && (error as! BlockchainServiceError) == .noUTXOsFound) {
+                        errors.append(error)
+                    }
+                }
+            }
+        }
+        dispatchGroup.notify(queue: .main) {
+            if !errors.isEmpty && combinedUTXOs.isEmpty {
+                completion(.failure(errors.first ?? BlockchainServiceError.addressDerivationFailed))
+            } else if combinedUTXOs.isEmpty {
+                completion(.failure(BlockchainServiceError.noUTXOsFound))
+            } else {
+                if !errors.isEmpty { print("Warning: Some derived addresses failed: \(errors.map { $0.localizedDescription })") }
+                completion(.success(combinedUTXOs))
+            }
+        }
+    }
+
+    private func performRequest(url: URL, completion: @escaping (Result<[UTXO], Error>) -> Void) {
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            DispatchQueue.main.async {
+                if let error = error { completion(.failure(BlockchainServiceError.networkError(error))); return }
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    completion(.failure(BlockchainServiceError.apiError("Invalid server response."))); return
+                }
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    var apiMsg = "API Error (Status: \(httpResponse.statusCode))."
+                    if let data = data, let msg = String(data: data, encoding: .utf8) { apiMsg += " Message: \(msg)"}
+                    completion(.failure(BlockchainServiceError.apiError(apiMsg))); return
+                }
+                guard let data = data else { completion(.failure(BlockchainServiceError.apiError("No data from API."))); return }
+                
+                do {
+                    let decoder = JSONDecoder()
+                    var utxos = try decoder.decode([UTXO].self, from: data)
+                    // Note: originAddress is populated by the calling methods (fetchUTXOsForSingleAddress, etc.)
+                    if utxos.isEmpty { completion(.failure(BlockchainServiceError.noUTXOsFound)) }
+                    else { completion(.success(utxos)) }
+                } catch {
+                    print("Decoding error: \(error) for URL: \(url)")
+                    if let jsonStr = String(data: data, encoding: .utf8) { print("Failed JSON: \(jsonStr.prefix(500))") }
+                    completion(.failure(BlockchainServiceError.decodingError(error)))
+                }
+            }
+        }.resume()
+    }
+}

--- a/BitcoinUTXOVisualizer/Utils/InputValidator.swift
+++ b/BitcoinUTXOVisualizer/Utils/InputValidator.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+struct InputValidator {
+    // Basic regex for Bitcoin addresses (covers P2PKH, P2SH, P2WPKH, P2TR)
+    // This is a simplified regex and might not cover all edge cases.
+    private let addressRegex = "^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$"
+    private let bech32AddressRegex = "^(bc1q|tb1q)[0-9a-z]{38,58}$" // More specific for P2WPKH/P2TR
+
+    // Basic regex for common xpub, ypub, zpub prefixes
+    // [xyz]pub[1-9A-HJ-NP-Za-km-z]{70,110} should be a more robust pattern
+    // but for simplicity, we'll check prefixes and general base58 characteristics.
+    private let xpubRegex = "^([xyz]pub|[tuv]pub)[a-zA-HJ-NP-Z0-9]{70,110}$"
+
+
+    func isValidInput(input: String) -> Bool {
+        let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Check if it's a single address or xpub
+        if isSingleAddress(trimmedInput) || isXpub(trimmedInput) {
+            return true
+        }
+
+        // Check if it's a comma-separated list of addresses
+        if isCommaSeparatedAddresses(trimmedInput) {
+            return true
+        }
+
+        return false
+    }
+
+    private func isSingleAddress(_ address: String) -> Bool {
+        // P2PKH starts with 1
+        // P2SH starts with 3
+        // P2WPKH/P2TR (Bech32) starts with bc1
+        // Testnet addresses often start with m, n, 2, tb1
+        if address.starts(with: "1") || address.starts(with: "3") {
+            return NSPredicate(format: "SELF MATCHES %@", addressRegex).evaluate(with: address) && address.count >= 26 && address.count <= 35
+        } else if address.starts(with: "bc1") || address.starts(with: "tb1") {
+             // Bech32/Bech32m can be longer
+            return NSPredicate(format: "SELF MATCHES %@", bech32AddressRegex).evaluate(with: address)
+        }
+        // Add other testnet prefixes if necessary e.g. m, n, 2
+        else if address.starts(with: "m") || address.starts(with: "n") || address.starts(with: "2"){
+             return NSPredicate(format: "SELF MATCHES %@", addressRegex).evaluate(with: address) && address.count >= 26 && address.count <= 35
+        }
+        return false
+    }
+
+    private func isXpub(_ xpub: String) -> Bool {
+        // Common prefixes: xpub, ypub, zpub (mainnet)
+        // tpub, upub, vpub (testnet)
+        let prefixes = ["xpub", "ypub", "zpub", "tpub", "upub", "vpub"]
+        if prefixes.contains(where: xpub.hasPrefix) {
+            // Basic check for length and characters (Base58)
+            // A full Base58 check is more complex.
+            return NSPredicate(format: "SELF MATCHES %@", xpubRegex).evaluate(with: xpub)
+        }
+        return false
+    }
+
+    private func isCommaSeparatedAddresses(_ input: String) -> Bool {
+        let addresses = input.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        if addresses.isEmpty {
+            return false
+        }
+        for address in addresses {
+            if !isSingleAddress(address) {
+                return false // If any address in the list is invalid
+            }
+        }
+        return true // All addresses in the list are valid
+    }
+}

--- a/BitcoinUTXOVisualizer/ViewModels/UTXOViewModel.swift
+++ b/BitcoinUTXOVisualizer/ViewModels/UTXOViewModel.swift
@@ -1,0 +1,274 @@
+import Foundation
+import Combine
+import SwiftUI
+
+// MARK: - Sorting Definitions
+enum UTXOSortField { /* ... (existing code) ... */ 
+    case amount
+    case age 
+    case status
+}
+enum SortDirection { /* ... (existing code) ... */ 
+    case ascending
+    case descending
+}
+struct UTXOSortDescriptor: Equatable { /* ... (existing code) ... */ 
+    var field: UTXOSortField
+    var direction: SortDirection
+
+    static var defaultSort: UTXOSortDescriptor {
+        UTXOSortDescriptor(field: .age, direction: .descending)
+    }
+}
+
+// MARK: - Filtering Definitions
+enum UTXOStatusFilter: String, CaseIterable, Identifiable { /* ... (existing code) ... */ 
+    case all = "All"
+    case confirmed = "Confirmed"
+    case unconfirmed = "Unconfirmed"
+
+    var id: String { self.rawValue }
+}
+
+class UTXOViewModel: ObservableObject {
+    // MARK: - Published Properties for UI
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String? = nil
+    @Published var currentInputSource: String? = nil
+    @Published private var sourceUTXOs: [UTXO] = []
+
+    @Published var sortDescriptor: UTXOSortDescriptor = .defaultSort
+    @Published var statusFilter: UTXOStatusFilter = .all
+    @Published var minAmountFilterBTC: String = ""
+    @Published var maxAmountFilterBTC: String = ""
+
+    @Published var showCSVExporter: Bool = false
+    @Published var csvFile: CSVFile? = nil
+    @Published var showJSONExporter: Bool = false
+    @Published var jsonFile: JSONFile? = nil
+
+    // MARK: - Analytics Properties
+    @Published var analyticsMultiUTXOAddresses: [String] = []
+    @Published var analyticsCommonSpendEvents: [String] = []
+
+
+    var filteredUTXOs: [UTXO] {
+        // ... (existing filtering and sorting logic) ...
+        var displayableUTXOs = sourceUTXOs
+        switch statusFilter {
+        case .confirmed: displayableUTXOs = displayableUTXOs.filter { $0.status == .confirmed }
+        case .unconfirmed: displayableUTXOs = displayableUTXOs.filter { $0.status == .unconfirmed }
+        case .all: break
+        }
+        let minSatoshis = btcStringToSatoshis(minAmountFilterBTC)
+        let maxSatoshis = btcStringToSatoshis(maxAmountFilterBTC)
+        if let min = minSatoshis { displayableUTXOs = displayableUTXOs.filter { $0.value >= min } }
+        if let max = maxSatoshis, max > 0 { displayableUTXOs = displayableUTXOs.filter { $0.value <= max } }
+        
+        displayableUTXOs.sort { (lhs, rhs) -> Bool in
+            switch sortDescriptor.field {
+            case .amount:
+                return sortDescriptor.direction == .ascending ? lhs.value < rhs.value : lhs.value > rhs.value
+            case .age:
+                if lhs.status == .confirmed && rhs.status == .confirmed {
+                    let lhsHeight = lhs.block_height ?? 0; let rhsHeight = rhs.block_height ?? 0
+                    return sortDescriptor.direction == .descending ? lhsHeight > rhsHeight : lhsHeight < rhsHeight
+                } else if lhs.status == .unconfirmed && rhs.status == .confirmed {
+                    return sortDescriptor.direction == .descending ? true : false
+                } else if lhs.status == .confirmed && rhs.status == .unconfirmed {
+                    return sortDescriptor.direction == .descending ? false : true
+                } else { return lhs.value > rhs.value }
+            case .status:
+                if lhs.status == .confirmed && rhs.status == .unconfirmed {
+                    return sortDescriptor.direction == .ascending ? false : true
+                } else if lhs.status == .unconfirmed && rhs.status == .confirmed {
+                    return sortDescriptor.direction == .ascending ? true : false
+                }
+                return lhs.value > rhs.value
+            }
+        }
+        
+        // Update analytics whenever filteredUTXOs changes
+        // Using a DispatchQueue.main.async to avoid modifying published properties during a view update cycle directly
+        DispatchQueue.main.async {
+            self.updateAnalytics(basedOn: displayableUTXOs)
+        }
+        return displayableUTXOs
+    }
+    
+    // ... (existing summary properties: totalBalanceSatoshis, etc.) ...
+    var totalBalanceSatoshis: Int64 { filteredUTXOs.reduce(0) { $0 + $1.value } }
+    var totalBalanceBTC: Double { Double(totalBalanceSatoshis) / 100_000_000.0 }
+    var utxoCount: Int { filteredUTXOs.count }
+    var confirmedUTXOCount: Int { filteredUTXOs.filter { $0.status == .confirmed }.count }
+    var unconfirmedUTXOCount: Int { filteredUTXOs.filter { $0.status == .unconfirmed }.count }
+    var formattedTotalBalance: String {
+        let formatter = NumberFormatter(); formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 8; formatter.minimumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: totalBalanceBTC)) ?? "0.00"
+    }
+    var hasActiveFilters: Bool { statusFilter != .all || !minAmountFilterBTC.isEmpty || !maxAmountFilterBTC.isEmpty }
+
+
+    private var blockchainService = BlockchainService()
+
+    // ... (existing fetchUTXOs, loadUTXOsFromFile, clearAndPrepareForLoad, handleLoadingError, clearFilters, btcStringToSatoshis, clearData methods) ...
+    func fetchUTXOs(forInput input: String) { 
+        clearAndPrepareForLoad()
+        isLoading = true
+
+        blockchainService.fetchUTXOs(forInput: input) { [weak self] result in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.isLoading = false
+                switch result {
+                case .success(let fetchedUTXOs):
+                    self.sourceUTXOs = fetchedUTXOs
+                    self.currentInputSource = "API: \(input)"
+                    if fetchedUTXOs.isEmpty {
+                        self.errorMessage = "No UTXOs found for the API input: \(input)."
+                    }
+                    // self.updateAnalytics(basedOn: self.filteredUTXOs) // Now handled by filteredUTXOs computed property
+                case .failure(let error):
+                    self.handleLoadingError(error)
+                    // self.updateAnalytics(basedOn: []) // Now handled by filteredUTXOs computed property
+                }
+            }
+        }
+    }
+    func loadUTXOsFromFile(fileURL: URL) { 
+        clearAndPrepareForLoad()
+        isLoading = true
+
+        do {
+            guard fileURL.startAccessingSecurityScopedResource() else {
+                self.isLoading = false; self.errorMessage = "Permission denied."; self.currentInputSource = nil
+                // self.updateAnalytics(basedOn: []) // Now handled by filteredUTXOs
+                return
+            }
+            let data = try Data(contentsOf: fileURL)
+            fileURL.stopAccessingSecurityScopedResource()
+
+            let decoder = JSONDecoder()
+            let fileUTXOs = try decoder.decode([UTXO].self, from: data)
+            
+            DispatchQueue.main.async {
+                self.isLoading = false; self.sourceUTXOs = fileUTXOs
+                self.currentInputSource = "File: \(fileURL.lastPathComponent)"
+                if fileUTXOs.isEmpty { self.errorMessage = "No UTXOs found in file." }
+                // self.updateAnalytics(basedOn: self.filteredUTXOs) // Now handled by filteredUTXOs
+            }
+        } catch {
+            fileURL.stopAccessingSecurityScopedResource()
+            DispatchQueue.main.async {
+                self.isLoading = false
+                self.handleLoadingError(error, context: "Error loading file.")
+                // self.updateAnalytics(basedOn: []) // Now handled by filteredUTXOs
+            }
+        }
+    }
+    private func clearAndPrepareForLoad() { 
+        isLoading = true; errorMessage = nil; sourceUTXOs = [] 
+        currentInputSource = nil
+        // Analytics will be cleared by updateAnalytics when sourceUTXOs becomes empty via filteredUTXOs
+    }
+    private func handleLoadingError(_ error: Error, context: String? = nil) { 
+        self.sourceUTXOs = [] // This will trigger analytics update via filteredUTXOs
+        if let serviceError = error as? BlockchainServiceError {
+            self.errorMessage = context != nil ? "\(context) \(serviceError.localizedDescription)" : serviceError.localizedDescription
+        } else {
+            self.errorMessage = context != nil ? "\(context) \(error.localizedDescription)" : error.localizedDescription
+        }
+        self.currentInputSource = nil
+    }
+    func clearFilters() { 
+        statusFilter = .all; minAmountFilterBTC = ""; maxAmountFilterBTC = ""
+        // objectWillChange.send() // To recompute filteredUTXOs and thus analytics
+    }
+    private func btcStringToSatoshis(_ btcString: String) -> Int64? { 
+        guard !btcString.isEmpty, let btcValue = Double(btcString.replacingOccurrences(of: ",", with: ".")) else { return nil }
+        if btcValue < 0 { return nil } 
+        return Int64(btcValue * 100_000_000.0)
+    }
+    func clearData() { 
+        sourceUTXOs = [] // This will trigger analytics update via filteredUTXOs
+        errorMessage = nil; currentInputSource = nil 
+    }
+
+
+    // MARK: - Analytics Logic
+    private func updateAnalytics(basedOn utxos: [UTXO]) {
+        // Multiple UTXOs per Address
+        var multiUTXOAddrResults: [String] = []
+        let utxosByOriginAddress = Dictionary(grouping: utxos.filter { $0.originAddress != nil }, by: { $0.originAddress! })
+        
+        for (address, groupedUtxos) in utxosByOriginAddress {
+            if groupedUtxos.count > 1 {
+                let shortAddress = address.count > 12 ? "\(address.prefix(6))...\(address.suffix(6))" : address
+                multiUTXOAddrResults.append("\(shortAddress) has \(groupedUtxos.count) UTXOs.")
+            }
+        }
+        self.analyticsMultiUTXOAddresses = multiUTXOAddrResults.sorted()
+
+        // Common Spending Transaction
+        var commonSpendResults: [String] = []
+        let spentUtxosWithSpendTxid = utxos.filter { $0.spent == true && $0.txid_spent != nil }
+        let utxosBySpendTxid = Dictionary(grouping: spentUtxosWithSpendTxid, by: { $0.txid_spent! })
+
+        for (spendTxid, groupedUtxos) in utxosBySpendTxid {
+            if groupedUtxos.count > 1 {
+                let utxoShortList = groupedUtxos.map { "\($0.txid.prefix(6))...:\($0.vout)" }.joined(separator: ", ")
+                let shortSpendTxid = spendTxid.count > 12 ? "\(spendTxid.prefix(6))...\(spendTxid.suffix(6))" : spendTxid
+                commonSpendResults.append("Common Spend: \(groupedUtxos.count) UTXOs spent in TXID \(shortSpendTxid) (UTXOs: \(utxoShortList))")
+            }
+        }
+        self.analyticsCommonSpendEvents = commonSpendResults.sorted()
+    }
+
+
+    // MARK: - Export Logic
+    func prepareCSVExport() { /* ... (existing code) ... */ 
+        let content = generateCSVString(from: filteredUTXOs)
+        self.csvFile = CSVFile(initialText: content)
+        self.showCSVExporter = true
+    }
+    func prepareJSONExport() { /* ... (existing code) ... */ 
+        guard let content = generateJSONString(from: filteredUTXOs) else {
+            self.errorMessage = "Failed to generate JSON data for export."
+            return
+        }
+        self.jsonFile = JSONFile(initialText: content)
+        self.showJSONExporter = true
+    }
+    private func generateCSVString(from utxos: [UTXO]) -> String { /* ... (existing code, ensure originAddress is included) ... */ 
+        var csvString = "TXID,Vout,Amount (BTC),Amount (Sats),Status,Block Height,Block Hash,Block Time,Age,Origin Address,Spent,Spend TXID,Spend Vin,Spend Status Confirmed,Spend Block Height,Spend Block Time\n" // Added Origin Address
+        let dateFormatter = DateFormatter(); dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        for utxo in utxos {
+            let txid = utxo.txid; let vout = "\(utxo.vout)"; let amountBTC = String(format: "%.8f", utxo.amountInBTC)
+            let amountSats = "\(utxo.value)"; let status = utxo.status == .confirmed ? "Confirmed" : "Unconfirmed"
+            let blockHeight = utxo.block_height != nil ? "\(utxo.block_height!)" : ""; let blockHash = utxo.block_hash ?? ""
+            let blockTime = utxo.block_time != nil ? dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(utxo.block_time!))) : ""; let age = utxo.age
+            let originAddress = utxo.originAddress ?? "" // Added
+            let spent = "\(utxo.spent ?? false)"; let spendTxid = utxo.txid_spent ?? ""; let spendVin = utxo.vin_spent != nil ? "\(utxo.vin_spent!)" : ""
+            var spendStatusConfirmed = ""; var spendBlockHeight = ""; var spendBlockTimeStr = ""
+            if let spendStatus = utxo.status_spent {
+                spendStatusConfirmed = "\(spendStatus.confirmed)"
+                if let sbh = spendStatus.block_height { spendBlockHeight = "\(sbh)" }
+                if let sbt = spendStatus.block_time { spendBlockTimeStr = dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(sbt))) }
+            }
+            let row = "\(txid),\(vout),\(amountBTC),\(amountSats),\(status),\(blockHeight),\(blockHash),\(blockTime),\"\(age)\",\(originAddress),\(spent),\(spendTxid),\(spendVin),\(spendStatusConfirmed),\(spendBlockHeight),\(spendBlockTimeStr)\n"
+            csvString.append(row)
+        }
+        return csvString
+    }
+    private func generateJSONString(from utxos: [UTXO]) -> String? { /* ... (existing code) ... */ 
+        let encoder = JSONEncoder(); encoder.outputFormatting = .prettyPrinted
+        do {
+            let jsonData = try encoder.encode(utxos)
+            return String(data: jsonData, encoding: .utf8)
+        } catch {
+            print("Error encoding UTXOs to JSON: \(error)"); self.errorMessage = "Error encoding data to JSON: \(error.localizedDescription)"
+            return nil
+        }
+    }
+}

--- a/BitcoinUTXOVisualizer/Views/ContentView.swift
+++ b/BitcoinUTXOVisualizer/Views/ContentView.swift
@@ -1,0 +1,355 @@
+import SwiftUI
+import UniformTypeIdentifiers 
+
+struct ContentView: View {
+    @StateObject private var viewModel = UTXOViewModel()
+    @State private var addressInput: String = "" 
+    @State private var showingFileImporter = false 
+    @State private var selectedUTXO: UTXO? = nil
+    @State private var showingAnalytics: Bool = true 
+    @State private var showingGraph: Bool = true // To make graph section collapsible in detail pane
+
+
+    @FocusState private var minAmountFieldIsFocused: Bool
+    @FocusState private var maxAmountFieldIsFocused: Bool
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 10) {
+                inputAndControlsArea()
+                
+                if let source = viewModel.currentInputSource {
+                    Text("Displaying data from: \(source)")
+                        .font(.caption).foregroundColor(.secondary).padding(.horizontal)
+                }
+
+                summaryBarArea()
+                exportButtonsArea().padding(.horizontal) 
+                analyticsInsightsArea().padding(.horizontal) 
+                utxoListArea()
+                detailPaneArea() // This will now include the graph
+            }
+            .navigationTitle("Bitcoin UTXO Visualizer")
+        }
+        .fileImporter(isPresented: $showingFileImporter, allowedContentTypes: [UTType.json], allowsMultipleSelection: false) { result in
+            handleFileImport(result: result)
+        }
+        .fileExporter(isPresented: $viewModel.showCSVExporter, document: viewModel.csvFile, contentType: UTType.commaSeparatedText, defaultFilename: "utxos.csv") { result in
+            handleExportResult(result, type: "CSV")
+        }
+        .fileExporter(isPresented: $viewModel.showJSONExporter, document: viewModel.jsonFile, contentType: UTType.json, defaultFilename: "utxos.json") { result in
+            handleExportResult(result, type: "JSON")
+        }
+        .frame(minWidth: 850, minHeight: 850) 
+    }
+
+    // MARK: - Subviews / Components
+    @ViewBuilder
+    private func inputAndControlsArea() -> some View { /* ... (remains unchanged) ... */ 
+        VStack(spacing: 10) {
+            HStack {
+                TextField("Enter Bitcoin Address, Addresses, or xpub", text: $addressInput)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .onSubmit { validateAndFetchAPI() }
+                Button("Fetch UTXOs") { validateAndFetchAPI() }
+            }
+            Button("Load UTXOs from File") { showingFileImporter = true }
+                .frame(maxWidth: .infinity, alignment: .center)
+            Divider()
+            Text("Filters").font(.title3)
+            HStack(spacing: 15) {
+                Picker("Status:", selection: $viewModel.statusFilter) {
+                    ForEach(UTXOStatusFilter.allCases) { status in Text(status.rawValue).tag(status) }
+                }
+                .pickerStyle(SegmentedPickerStyle()).frame(minWidth: 200)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Amount (BTC):").font(.caption)
+                    HStack {
+                        TextField("Min", text: $viewModel.minAmountFilterBTC)
+                            .textFieldStyle(RoundedBorderTextFieldStyle()).frame(width: 80)
+                            .keyboardType(.decimalPad).focused($minAmountFieldIsFocused)
+                        Text("-")
+                        TextField("Max", text: $viewModel.maxAmountFilterBTC)
+                            .textFieldStyle(RoundedBorderTextFieldStyle()).frame(width: 80)
+                            .keyboardType(.decimalPad).focused($maxAmountFieldIsFocused)
+                    }
+                }
+                Button("Clear Filters") { viewModel.clearFilters() }.padding(.top, 15)
+                Spacer()
+            }
+            Divider()
+            Text("Sort By").font(.title3)
+            HStack(spacing: 15) {
+                Picker("Field:", selection: $viewModel.sortDescriptor.field) {
+                    Text("Amount").tag(UTXOSortField.amount); Text("Age/Block").tag(UTXOSortField.age); Text("Status").tag(UTXOSortField.status)
+                }
+                .pickerStyle(SegmentedPickerStyle()).frame(minWidth: 200)
+                Picker("Direction:", selection: $viewModel.sortDescriptor.direction) {
+                    Text("Ascending").tag(SortDirection.ascending); Text("Descending").tag(SortDirection.descending)
+                }
+                .pickerStyle(SegmentedPickerStyle()).frame(minWidth: 180)
+                Spacer()
+            }
+        }
+        .padding([.horizontal, .top])
+    }
+    @ViewBuilder
+    private func summaryBarArea() -> some View { /* ... (remains unchanged) ... */ 
+        SummaryBarView(
+            totalBalance: "\(viewModel.formattedTotalBalance) BTC",
+            utxoCount: "\(viewModel.filteredUTXOs.count)",
+            confirmedCount: viewModel.confirmedUTXOCount,
+            unconfirmedCount: viewModel.unconfirmedUTXOCount
+        )
+        .padding(.horizontal)
+    }
+    @ViewBuilder
+    private func exportButtonsArea() -> some View { /* ... (remains unchanged) ... */ 
+        HStack {
+            Spacer() 
+            Button { viewModel.prepareCSVExport() } label: { Label("Export as CSV", systemImage: "square.and.arrow.down") }
+            .disabled(viewModel.filteredUTXOs.isEmpty) 
+            Button { viewModel.prepareJSONExport() } label: { Label("Export as JSON", systemImage: "square.and.arrow.down") }
+            .disabled(viewModel.filteredUTXOs.isEmpty) 
+            Spacer()
+        }
+        .padding(.vertical, 5)
+    }
+    @ViewBuilder
+    private func analyticsInsightsArea() -> some View { /* ... (remains unchanged) ... */ 
+        DisclosureGroup("Analytics Insights", isExpanded: $showingAnalytics) {
+            VStack(alignment: .leading, spacing: 8) {
+                if viewModel.analyticsMultiUTXOAddresses.isEmpty && viewModel.analyticsCommonSpendEvents.isEmpty {
+                    Text("No specific address reuse or common spending patterns detected in the current set.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    if !viewModel.analyticsMultiUTXOAddresses.isEmpty {
+                        Text("Multiple UTXOs per Address:").font(.headline.weight(.medium))
+                        ForEach(viewModel.analyticsMultiUTXOAddresses, id: \.self) { insight in
+                            Text("• \(insight)").font(.caption)
+                        }
+                    }
+                    if !viewModel.analyticsCommonSpendEvents.isEmpty {
+                        Text("Common Spending Events:").font(.headline.weight(.medium)).padding(.top, 5)
+                        ForEach(viewModel.analyticsCommonSpendEvents, id: \.self) { insight in
+                            Text("• \(insight)").font(.caption)
+                        }
+                    }
+                }
+            }
+            .padding(.top, 5)
+        }
+        .padding(.vertical, 5)
+    }
+    @ViewBuilder
+    private func utxoListArea() -> some View { /* ... (remains unchanged) ... */ 
+        Group {
+            if viewModel.isLoading {
+                ProgressView("Loading UTXOs...").frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorMessage = viewModel.errorMessage {
+                errorDisplayView(errorMessage)
+            } else if viewModel.filteredUTXOs.isEmpty {
+                emptyStateView()
+            } else {
+                List(viewModel.filteredUTXOs, selection: $selectedUTXO) { utxo in
+                    UTXORowView(utxo: utxo).tag(utxo)
+                        .contextMenu {
+                            Button(action: { copyToClipboard(utxo.txid) }) { Text("Copy TXID"); Image(systemName: "doc.on.doc") }
+                        }
+                }
+                .border(Color.gray.opacity(0.3))
+            }
+        }
+        .frame(minHeight: 200, maxHeight: .infinity) 
+        .padding(.horizontal)
+    }
+    
+    @ViewBuilder
+    private func errorDisplayView(_ message: String) -> some View { /* ... (remains unchanged) ... */ 
+        VStack {
+            Image(systemName: "xmark.octagon.fill").resizable().aspectRatio(contentMode: .fit)
+                .frame(width: 40, height: 40).foregroundColor(.red)
+            Text(message).foregroundColor(.red).padding().multilineTextAlignment(.center)
+            Button("Dismiss & Clear") {
+                viewModel.errorMessage = nil; viewModel.clearData(); viewModel.clearFilters()
+            }.padding(.top, 1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    @ViewBuilder
+    private func emptyStateView() -> some View { /* ... (remains unchanged) ... */ 
+        let message = viewModel.hasActiveFilters ? "No UTXOs match the current filters." :
+                      (viewModel.currentInputSource != nil ? "No UTXOs found from the source." : "Enter an address/xpub and click 'Fetch UTXOs' or load from a file.")
+        Text(message).foregroundColor(.secondary).multilineTextAlignment(.center)
+            .padding().frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Updated Detail Pane
+    @ViewBuilder
+    private func detailPaneArea() -> some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("Selected UTXO Details").font(.title3)
+                Spacer()
+                if selectedUTXO != nil {
+                    Button(action: { selectedUTXO = nil }) { 
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .foregroundColor(.gray)
+                    .buttonStyle(BorderlessButtonStyle())
+                }
+            }.padding(.bottom, 5)
+
+            if let utxo = selectedUTXO {
+                // Use a TabView or similar if space becomes an issue. For now, VStack.
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        // Textual Details
+                        DetailRow(label: "TXID", value: utxo.txid, isMonospaced: true, showCopy: true)
+                        DetailRow(label: "Vout", value: "\(utxo.vout)")
+                        DetailRow(label: "Amount", value: "\(utxo.amountInBTC, specifier: "%.8f") BTC (\(utxo.value) sats)")
+                        DetailRow(label: "Origin Addr.", value: utxo.originAddress ?? "N/A", isMonospaced: true, showCopy: (utxo.originAddress != nil))
+                        Divider().padding(.vertical, 4)
+                        DetailRow(label: "Status", value: utxo.status == .confirmed ? "Confirmed" : "Unconfirmed",
+                                  color: utxo.status == .confirmed ? .green : .orange)
+                        if utxo.status == .confirmed {
+                            if let blockHeight = utxo.block_height { DetailRow(label: "Block Height", value: "\(blockHeight)") }
+                            if let blockHash = utxo.block_hash { DetailRow(label: "Block Hash", value: blockHash, isMonospaced: true, showCopy: true) }
+                            if let blockTime = utxo.block_time { DetailRow(label: "Block Time", value: formatTimestamp(blockTime)) }
+                        }
+                        Divider().padding(.vertical, 4)
+                        let isSpent = utxo.spent ?? false
+                        DetailRow(label: "Spend Status", value: isSpent ? "Spent" : "Unspent", color: isSpent ? .red : .blue)
+                        if isSpent {
+                            if let spendingTxid = utxo.txid_spent { DetailRow(label: "Spent in TXID", value: spendingTxid, isMonospaced: true, showCopy: true, isLink: true, linkURL: "https://mempool.space/tx/\(spendingTxid)") }
+                            if let spendingVin = utxo.vin_spent { DetailRow(label: "Spending Vin", value: "\(spendingVin)") }
+                            if let spendingStatus = utxo.status_spent {
+                                DetailRow(label: "Spend Confirmed", value: spendingStatus.confirmed ? "Yes" : "No", color: spendingStatus.confirmed ? .green : .orange)
+                                if spendingStatus.confirmed {
+                                    if let spendBlockHeight = spendingStatus.block_height { DetailRow(label: "Spend Block", value: "\(spendBlockHeight)") }
+                                   if let spendBlockTime = spendingStatus.block_time { DetailRow(label: "Spend Time", value: formatTimestamp(spendBlockTime)) }
+                                }
+                            }
+                        }
+                        Divider().padding(.vertical, 4)
+                        DetailRow(label: "ScriptPubKey", value: "Not available via current API endpoint", isItalic: true)
+                        Divider().padding(.vertical, 4)
+                        Text("Explore:").font(.caption.weight(.medium))
+                        if let url = URL(string: "https://mempool.space/tx/\(utxo.txid)") { Link("View Originating Transaction", destination: url).font(.caption) }
+                        let validator = InputValidator()
+                        if let origin = utxo.originAddress, validator.isSingleAddress(origin) { 
+                             if let url = URL(string: "https://mempool.space/address/\(origin.trimmingCharacters(in: .whitespacesAndNewlines))") {
+                                Link("View Origin Address (\(origin.trimmingCharacters(in: .whitespacesAndNewlines).prefix(6))...)", destination: url).font(.caption).help("Link to the UTXO's origin address.")
+                            }
+                        } else if validator.isSingleAddress(addressInput) { 
+                             if let url = URL(string: "https://mempool.space/address/\(addressInput.trimmingCharacters(in: .whitespacesAndNewlines))") {
+                                Link("View Input Address (\(addressInput.trimmingCharacters(in: .whitespacesAndNewlines).prefix(6))...)", destination: url).font(.caption).help("Link to the address entered in the input field, if it was a single address.")
+                            }
+                        } else { Text("Address Link: N/A").font(.caption2).foregroundColor(.gray) }
+                        
+                        Divider().padding(.vertical, 8)
+
+                        // Graphical Visualization Section
+                        DisclosureGroup("Transaction Flow Graph", isExpanded: $showingGraph) {
+                             SelectedUTXOGraphView(utxo: utxo)
+                                .padding(.top, 5)
+                        }
+                    }
+                }
+            } else { 
+                Text("Select a UTXO from the list to see its details and graph here.")
+                    .foregroundColor(.secondary)
+                Spacer() 
+            }
+        }
+        .padding()
+        .frame(minHeight: 250, maxHeight: .infinity) 
+        .frame(maxWidth: .infinity)
+        .background(Color.gray.opacity(0.08)) 
+        .cornerRadius(8)
+        .padding([.horizontal, .bottom])
+    }
+    
+    // MARK: - Helper Functions
+    private func validateAndFetchAPI() { /* ... (remains unchanged) ... */ 
+        viewModel.clearData();
+        let validator = InputValidator()
+        if validator.isValidInput(input: addressInput) {
+            viewModel.fetchUTXOs(forInput: addressInput)
+        } else {
+            viewModel.errorMessage = "Invalid input format for API fetch."
+        }
+    }
+    private func handleFileImport(result: Result<[URL], Error>) { /* ... (remains unchanged) ... */ 
+        viewModel.clearData();
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { viewModel.errorMessage = "Could not get file URL."; return }
+            viewModel.loadUTXOsFromFile(fileURL: url)
+        case .failure(let error):
+            viewModel.errorMessage = "Failed to select file: \(error.localizedDescription)"
+        }
+    }
+    private func copyToClipboard(_ string: String) { /* ... (remains unchanged) ... */ 
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+    }
+    private func formatTimestamp(_ timestamp: Int) -> String { /* ... (remains unchanged) ... */ 
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let formatter = DateFormatter(); formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.string(from: date)
+    }
+    private func handleExportResult(_ result: Result<URL, Error>, type: String) { /* ... (remains unchanged) ... */ 
+        switch result {
+        case .success(let url): print("\(type) exported successfully to \(url.path)")
+        case .failure(let error): print("Error exporting \(type): \(error.localizedDescription)"); viewModel.errorMessage = "Error exporting \(type): \(error.localizedDescription)"
+        }
+    }
+}
+
+// UTXORowView (remains unchanged)
+struct UTXORowView: View { /* ... */ 
+    let utxo: UTXO
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle().fill(utxo.status == .confirmed ? Color.green.opacity(0.7) : Color.orange.opacity(0.7)).frame(width: 10, height: 10)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack { Text(utxo.txid).font(.system(.caption, design: .monospaced)).lineLimit(1).truncationMode(.middle).help(utxo.txid); Text(":\(utxo.vout)").font(.system(.caption, design: .monospaced)) }
+                Text("Amount: \(utxo.amountInBTC, specifier: "%.8f") BTC (\(utxo.value) sats)").font(.caption2)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(utxo.status == .confirmed ? "Confirmed" : "Unconfirmed").font(.caption.weight(.medium)).foregroundColor(utxo.status == .confirmed ? .green : .orange)
+                Text(utxo.age).font(.caption2)
+            }
+        }
+        .padding(.vertical, 5)
+    }
+}
+
+// DetailRow (remains unchanged)
+struct DetailRow: View { /* ... */ 
+    let label: String; let value: String; var color: Color? = nil; var isMonospaced: Bool = false; var showCopy: Bool = false; var isLink: Bool = false; var linkURL: String? = nil; var isItalic: Bool = false
+    var body: some View {
+        HStack(alignment: .top) {
+            Text("\(label):").font(.caption.weight(.medium)).frame(width: 100, alignment: .trailing).padding(.trailing, 5)
+            Group {
+                if isLink, let urlString = linkURL, let url = URL(string: urlString) { Link(value, destination: url).font(isMonospaced ? .system(.caption, design: .monospaced) : .caption).if(isItalic) { $0.italic() } }
+                else { Text(value).font(isMonospaced ? .system(.caption, design: .monospaced) : .caption).if(isItalic) { $0.italic() } }
+            }
+            .foregroundColor(color).lineLimit(1).truncationMode(.middle).help(value)
+            if showCopy { Button(action: { NSPasteboard.general.clearContents(); NSPasteboard.general.setString(value, forType: .string) }) { Image(systemName: "doc.on.doc") }.buttonStyle(BorderlessButtonStyle()) }
+            Spacer()
+        }
+    }
+}
+
+// Helper for conditional modifier (remains unchanged)
+extension View { /* ... */ 
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View { if condition { transform(self) } else { self } }
+}
+
+struct ContentView_Previews: PreviewProvider { /* ... (remains unchanged) ... */ 
+    static var previews: some View { let vm = UTXOViewModel(); return ContentView().environmentObject(vm) }
+}

--- a/BitcoinUTXOVisualizer/Views/SelectedUTXOGraphView.swift
+++ b/BitcoinUTXOVisualizer/Views/SelectedUTXOGraphView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+struct SelectedUTXOGraphView: View {
+    let utxo: UTXO
+
+    private func truncateTxid(_ txid: String?) -> String {
+        guard let txid = txid, !txid.isEmpty else { return "N/A" }
+        return txid.count > 10 ? "\(txid.prefix(6))...\(txid.suffix(4))" : txid
+    }
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) { // Reduced spacing
+            Text("Simplified Transaction Flow")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.bottom, 10)
+
+            HStack(spacing: 0) { // Nodes and arrows in HStack
+                // Creation Transaction Node
+                NodeView(label: "Creation TX", id: truncateTxid(utxo.txid), color: .blue)
+                
+                ArrowView()
+
+                // Selected UTXO Node
+                NodeView(label: "Selected UTXO", id: "\(utxo.amountInBTC, specifier: "%.8f") BTC", color: .green)
+
+                // Spending Transaction (if applicable)
+                if utxo.spent == true, let spendingTxid = utxo.txid_spent {
+                    ArrowView()
+                    NodeView(label: "Spending TX", id: truncateTxid(spendingTxid), color: .red)
+                } else {
+                    // If not spent, add a spacer to keep UTXO node centered if there's no spending tx
+                    // Or, add a placeholder indicating "Unspent"
+                    ArrowView(isPlaceholder: true) // Dotted or lighter arrow
+                    NodeView(label: "Status", id: "Unspent", color: .gray.opacity(0.5), isFaded: true)
+                }
+            }
+            .frame(maxWidth: .infinity) // Allow HStack to take available width
+            .padding(.horizontal) // Add some horizontal padding
+
+            Text("Note: This is a simplified view and does not show other inputs/outputs.")
+                .font(.caption2)
+                .foregroundColor(.gray)
+                .padding(.top, 10)
+        }
+        .padding(.vertical)
+        .background(Color.gray.opacity(0.05)) // Light background for the graph area
+        .cornerRadius(5)
+    }
+}
+
+struct NodeView: View {
+    let label: String
+    let id: String
+    let color: Color
+    var isFaded: Bool = false
+
+    var body: some View {
+        VStack {
+            Text(label)
+                .font(.caption2)
+                .foregroundColor(isFaded ? .gray : .primary)
+            RoundedRectangle(cornerRadius: 8)
+                .fill(color.opacity(isFaded ? 0.3 : 1.0))
+                .frame(minWidth: 80, idealWidth: 100, maxWidth: 120, minHeight: 40, idealHeight: 50, maxHeight: 60) // Flexible sizing
+                .overlay(
+                    Text(id)
+                        .font(.system(size: 10, design: .monospaced))
+                        .padding(4)
+                        .foregroundColor(.white)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                )
+        }
+        .padding(.horizontal, 5) // Padding between node and arrow
+    }
+}
+
+struct ArrowView: View {
+    var isPlaceholder: Bool = false
+    
+    var body: some View {
+        Path { path in
+            path.move(to: CGPoint(x: 0, y: 10))
+            path.addLine(to: CGPoint(x: 30, y: 10)) // Arrow line
+            
+            // Arrowhead
+            if !isPlaceholder {
+                path.move(to: CGPoint(x: 30, y: 10))
+                path.addLine(to: CGPoint(x: 25, y: 5))
+                path.move(to: CGPoint(x: 30, y: 10))
+                path.addLine(to: CGPoint(x: 25, y: 15))
+            }
+        }
+        .stroke(isPlaceholder ? Color.gray.opacity(0.5) : Color.primary, style: StrokeStyle(lineWidth: 2, lineCap: .round, dash: isPlaceholder ? [3,3] : []))
+        .frame(width: 30, height: 20) // Fixed size for the arrow
+        .padding(.horizontal, 2) // Small padding around arrow
+    }
+}
+
+// Preview
+struct SelectedUTXOGraphView_Previews: PreviewProvider {
+    static var sampleUnspentUTXO: UTXO {
+        // Manually create a UTXO instance. Ensure all required fields are present.
+        // This requires knowing the structure of ConfirmationStatusDetails.
+        let statusDetails = UTXO.ConfirmationStatusDetails(confirmed: true, block_height: 123456, block_hash: "dummyhash", block_time: 1600000000)
+        // For this preview, we'll use a simplified UTXO that might not be fully valid for other parts of the app
+        // but is sufficient for previewing the graph view.
+        // In a real app, you might have a mock UTXO generator.
+        // The UTXO initializer expects all non-optional fields.
+        // We will assume a simple JSON structure for preview if the full init is complex.
+        // For simplicity, let's assume we can directly construct it if all fields are known.
+        // This is a placeholder for a real UTXO instance.
+        // Actual preview would require constructing a valid UTXO.
+        // The UTXO model has a complex init(from: Decoder). For preview, it's easier to use JSON.
+        let json = """
+        {
+            "txid": "preview_txid_unspent_12345",
+            "vout": 0,
+            "status": { "confirmed": true, "block_height": 700000, "block_hash": "somehash", "block_time": 1600000000 },
+            "value": 100000,
+            "spent": false,
+            "originAddress": "preview_address_unspent"
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        return try! decoder.decode(UTXO.self, from: json)
+    }
+
+    static var sampleSpentUTXO: UTXO {
+        let json = """
+        {
+            "txid": "preview_txid_spent_67890",
+            "vout": 1,
+            "status": { "confirmed": true, "block_height": 650000, "block_hash": "anotherhash", "block_time": 1500000000 },
+            "value": 50000,
+            "spent": true,
+            "txid_spent": "preview_txid_spending_abcde",
+            "vin_spent": 2,
+            "status_spent": { "confirmed": true, "block_height": 650010, "block_hash": "spendhash", "block_time": 1500010000 },
+            "originAddress": "preview_address_spent"
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        return try! decoder.decode(UTXO.self, from: json)
+    }
+    
+    static var previews: some View {
+        VStack(spacing: 30) {
+            SelectedUTXOGraphView(utxo: sampleUnspentUTXO)
+            SelectedUTXOGraphView(utxo: sampleSpentUTXO)
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/BitcoinUTXOVisualizer/Views/SummaryBarView.swift
+++ b/BitcoinUTXOVisualizer/Views/SummaryBarView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct SummaryBarView: View {
+    var totalBalance: String // Formatted BTC string
+    var utxoCount: String    // Total count of displayed UTXOs
+    var confirmedCount: Int
+    var unconfirmedCount: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("Total Balance:")
+                    .font(.headline)
+                Text(totalBalance)
+                    .font(.headline.monospaced()) // Monospaced for numbers
+                Spacer()
+            }
+            HStack {
+                 Text("Displaying UTXOs:")
+                    .font(.caption)
+                Text(utxoCount) // Total displayed
+                    .font(.caption.weight(.semibold))
+                
+                if confirmedCount > 0 || unconfirmedCount > 0 { // Only show breakdown if relevant
+                    Text("(\(confirmedCount) Confirmed, \(unconfirmedCount) Unconfirmed)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12) // Add some horizontal padding too
+        .background(Color.gray.opacity(0.15))
+        .cornerRadius(8)
+    }
+}
+
+struct SummaryBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        SummaryBarView(
+            totalBalance: "1.23456789 BTC",
+            utxoCount: "15",
+            confirmedCount: 10,
+            unconfirmedCount: 5
+        )
+        .padding()
+        .previewLayout(.sizeThatFits)
+        
+        SummaryBarView(
+            totalBalance: "0.00000000 BTC",
+            utxoCount: "0",
+            confirmedCount: 0,
+            unconfirmedCount: 0
+        )
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/BitcoinUTXOVisualizer/sample_utxos.json
+++ b/BitcoinUTXOVisualizer/sample_utxos.json
@@ -1,0 +1,87 @@
+[
+  {
+    "txid": "fictional_txid_abc123_confirmed_unspent",
+    "vout": 0,
+    "status": {
+      "confirmed": true,
+      "block_height": 750000,
+      "block_hash": "0000000000000000000a1b2c3d4e5f6g7h8i9j0k",
+      "block_time": 1678886400 
+    },
+    "value": 12345678,
+    "spent": false,
+    "originAddress": "address_alpha"
+  },
+  {
+    "txid": "fictional_txid_def456_unconfirmed_unspent",
+    "vout": 1,
+    "status": {
+      "confirmed": false
+    },
+    "value": 87654321,
+    "spent": false,
+    "originAddress": "address_beta"
+  },
+  {
+    "txid": "fictional_txid_ghi789_confirmed_SPENT",
+    "vout": 2,
+    "status": { 
+      "confirmed": true,
+      "block_height": 650000,
+      "block_hash": "0000000000000000000z9y8x7w6v5u4t3s2r1q0p",
+      "block_time": 1600000000
+    },
+    "value": 50000000,
+    "spent": true,
+    "txid_spent": "spending_tx_id_001",
+    "vin_spent": 3,
+    "status_spent": {
+      "confirmed": true,
+      "block_height": 780005,
+      "block_hash": "0000000000000000000sPeNdInGbLoCkHaSh001",
+      "block_time": 1690001000
+    },
+    "originAddress": "address_alpha" 
+  },
+  {
+    "txid": "fictional_txid_jkl012_confirmed_zero_value_unspent",
+    "vout": 0,
+    "status": {
+      "confirmed": true,
+      "block_height": 780000,
+      "block_hash": "0000000000000000000m1n2o3p4q5r6s7t8u9v0w",
+      "block_time": 1690000000
+    },
+    "value": 0,
+    "spent": false,
+    "originAddress": "address_gamma"
+  },
+  {
+    "txid": "fictional_txid_mno345_unconfirmed_small_value_SPENT_unconfirmed_spend",
+    "vout": 3,
+    "status": { 
+      "confirmed": false 
+    },
+    "value": 10000,
+    "spent": true,
+    "txid_spent": "spending_tx_id_001", 
+    "vin_spent": 0,
+    "status_spent": {
+        "confirmed": false
+    },
+    "originAddress": "address_beta"
+  },
+  {
+    "txid": "fictional_txid_pqr678_confirmed_unspent_another_alpha",
+    "vout": 0,
+    "status": {
+      "confirmed": true,
+      "block_height": 790000,
+      "block_hash": "0000000000000000000aBcDeFgHiJkLmNoPqRsTuV",
+      "block_time": 1700000000 
+    },
+    "value": 25000000,
+    "spent": false,
+    "originAddress": "address_alpha" 
+  }
+]


### PR DESCRIPTION
This commit introduces the core functionality for the Bitcoin UTXO Visualizer, a macOS desktop application for blockchain analysis.

Key Features Implemented:

1.  **Project Setup:** Swift/SwiftUI project with input validation.
2.  **UTXO Fetching:** Fetches UTXOs from Mempool.space API for single/multiple addresses and simulated xpubs. Displays results in a list.
3.  **Offline Mode:** Supports loading UTXO data from your selected JSON files. Includes a sample JSON data file.
4.  **UTXO Visualization:**
    *   Detailed list view showing TXID, vout, amount (BTC/sats), block height, status, and age.
    *   Sorting by amount, age, status.
    *   Filtering by status and amount range.
    *   Dynamic summary bar reflecting filtered data (total balance, count, status breakdown).
5.  **Detail Pane:** Comprehensive view for selected UTXO, including confirmation status, spend status (with explorer links), and links to originating transaction/address.
6.  **Data Export:** Allows export of the filtered UTXO list to CSV and JSON formats.
7.  **Advanced Analytics (Optional):**
    *   Identifies addresses with multiple UTXOs in the current set.
    *   Detects common spending transactions (multiple UTXOs spent in the same TX).
    *   Analytics displayed in a dedicated UI section and update with filters.
8.  **Graphical Visualization (Optional):**
    *   Simple static graph for a selected UTXO, showing its creation and spending transaction (if applicable), displayed in the detail pane.

The application provides robust functionality for fetching, viewing, analyzing, and exporting UTXO data, catering to blockchain researchers and analysts. Further work would involve UI/UX refinements, accessibility enhancements, and comprehensive documentation (README).